### PR TITLE
Update firebase to solve 501 server errors

### DIFF
--- a/frontend/firebase-messaging-sw.js
+++ b/frontend/firebase-messaging-sw.js
@@ -2,8 +2,8 @@
 // Give the service worker access to Firebase Messaging.
 // Note that you can only use Firebase Messaging here, other Firebase libraries
 // are not available in the service worker.
-importScripts('https://www.gstatic.com/firebasejs/3.9.0/firebase-app.js');
-importScripts('https://www.gstatic.com/firebasejs/3.9.0/firebase-messaging.js');
+importScripts('https://www.gstatic.com/firebasejs/7.0.0/firebase-app.js');
+importScripts('https://www.gstatic.com/firebasejs/7.0.0/firebase-messaging.js');
 
 // Initialize the Firebase app in the service worker by passing in the
 // messagingSenderId.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -80,7 +80,7 @@ limitations under the License.
         4. Replace the following initialization code with the code from the Firebase console:
 -->
 <!-- START INITIALIZATION CODE -->
-<script src="https://www.gstatic.com/firebasejs/4.1.2/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/7.0.0/firebase.js"></script>
 <script>
   // Initialize Firebase
   var config = {
@@ -88,7 +88,8 @@ limitations under the License.
     authDomain: "fcm-test-88425.firebaseapp.com",
     databaseURL: "https://fcm-test-88425.firebaseio.com",
     storageBucket: "fcm-test-88425.appspot.com",
-    messagingSenderId: "343960876538"
+    messagingSenderId: "343960876538",
+    appId: "1:343960876538:web:ou8Phiexoo8ieWax9kedo8"
   };
   firebase.initializeApp(config);
 </script>


### PR DESCRIPTION
It seems that the version 4.2.1 of Firebase now hase some weird behavior when trying to subscribe, as the API now responsd with a 501 status:

![image](https://github.com/user-attachments/assets/4038212c-6fe8-4c57-b705-30e292b8fd27)

Updating to 7.0.0 fixes this, but also requires adding the `appId` in the config.

I also updated the firebase version in the service worker.